### PR TITLE
feat: HashSet

### DIFF
--- a/code/code.go
+++ b/code/code.go
@@ -35,6 +35,7 @@ const (
 	OpNull
 	OpGetGlobal
 	OpSetGlobal
+	OpArray
 )
 
 // maping opcode definitions
@@ -109,6 +110,11 @@ var definitions = map[Opcode]*Definition{
 	// | OpSetGlobal | 2 byte integer    |
 	// +-------------+---------+---------+
 	OpSetGlobal: {"OpSetGlobal", []int{2}},
+
+	OpArray: {"OpArray", []int{2}},
+	// +---------+-----------------+
+	// | OpArray | length of array |
+	// +---------+-----------------+
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/code/code.go
+++ b/code/code.go
@@ -36,6 +36,7 @@ const (
 	OpGetGlobal
 	OpSetGlobal
 	OpArray
+	OpHash
 )
 
 // maping opcode definitions
@@ -115,6 +116,10 @@ var definitions = map[Opcode]*Definition{
 	// +---------+------------------+
 	// | OpArray | N (array length) |
 	// +---------+------------------+
+	OpHash: {"OpHash", []int{2}},
+	// +--------+---------------+
+	// | OpHash | N (hash size) | // length of keys and values are the same
+	// +--------+---------------+
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -247,6 +247,51 @@ func TestArrayLiterals(t *testing.T) {
 	runCompilerTests(t, tests)
 }
 
+func TestHashLiterals(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             "{}",
+			expectedConstants: []interface{}{},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpHash, 0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "{1:2, 3:4, 5:6}",
+			expectedConstants: []interface{}{1, 2, 3, 4, 5, 6},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpConstant, 3),
+				code.Make(code.OpConstant, 4),
+				code.Make(code.OpConstant, 5),
+				code.Make(code.OpHash, 6), // every odd element is a key, every even element is a value
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "{1:2+3, 4:5*6}",
+			expectedConstants: []interface{}{1, 2, 3, 4, 5, 6},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpAdd),
+				code.Make(code.OpConstant, 3),
+				code.Make(code.OpConstant, 4),
+				code.Make(code.OpConstant, 5),
+				code.Make(code.OpMul),
+				code.Make(code.OpHash, 4), // every odd element is a key, every even element is a value
+				code.Make(code.OpPop),
+			},
+		},
+	}
+
+	runCompilerTests(t, tests)
+}
+
 // testing the compiler and making assertions about the output
 func runCompilerTests(t *testing.T, tests []compilerTestCase) {
 	t.Helper()


### PR DESCRIPTION
adding the OpHash operator and adding basic hashset functionality to the compiler and vm

`{key: value}` is now valid syntax
where `key` and `value` are expressions